### PR TITLE
Fix the issue where bsl_list does not adjust the current node

### DIFF
--- a/bsl/list/src/bsl_list_ex.c
+++ b/bsl/list/src/bsl_list_ex.c
@@ -140,33 +140,36 @@ void BSL_LIST_DetachNode(BslList *pstList, BslListNode **pstListNode)
 
     BslListNode *pstCurrentNode = pstList->first;
     while (pstCurrentNode != NULL) {
-        if (pstCurrentNode == *pstListNode) {
-            // found matching node, delete this node and adjust the list
-            if ((pstCurrentNode->next) != NULL) {
-                pstCurrentNode->next->prev = pstCurrentNode->prev;
+        if (pstCurrentNode != *pstListNode) {
+            pstCurrentNode = pstCurrentNode->next;
+            continue;
+        }
+        // found matching node, delete this node and adjust the list
+        if ((pstCurrentNode->next) != NULL) {
+            pstCurrentNode->next->prev = pstCurrentNode->prev;
+            if (*pstListNode == pstList->curr) {
                 pstList->curr = pstCurrentNode->next;
-                *pstListNode = pstCurrentNode->next; // update the current node and point it to the next node
-            } else {
-                pstList->last = pstCurrentNode->prev;
+            }
+            *pstListNode = pstCurrentNode->next; // update the current node and point it to the next node
+        } else {
+            pstList->last = pstCurrentNode->prev;
+            if (*pstListNode == pstList->curr) {
                 pstList->curr = pstCurrentNode->prev;
-                *pstListNode = pstList->last;
             }
-
-            if ((pstCurrentNode->prev) != NULL) {
-                pstCurrentNode->prev->next = pstCurrentNode->next;
-            } else {
-                pstList->first = pstCurrentNode->next;
-            }
-
-            pstList->count--;
-
-            BSL_SAL_FREE(pstCurrentNode);
-            return;
+            *pstListNode = pstList->last;
         }
 
-        pstCurrentNode = pstCurrentNode->next;
-    }
+        if ((pstCurrentNode->prev) != NULL) {
+            pstCurrentNode->prev->next = pstCurrentNode->next;
+        } else {
+            pstList->first = pstCurrentNode->next;
+        }
 
+        pstList->count--;
+
+        BSL_SAL_FREE(pstCurrentNode);
+        return;
+    }
     return;
 }
 #endif /* HITLS_BSL_LIST */

--- a/testcode/sdv/testcase/bsl/list/test_suite_sdv_list.c
+++ b/testcode/sdv/testcase/bsl/list/test_suite_sdv_list.c
@@ -316,6 +316,17 @@ void SDV_BSL_LIST_DETACH_FUNC_TC001(void)
     BslListNode *detachNode = testList->first->next->next->next;
     BSL_LIST_DetachNode(testList, &detachNode);
     ASSERT_TRUE(UserDataCompare(detachNode->data, &data[4]) == 0); // Dave's position became Emma.
+    /* When the deleted node is the current node, the current node will be
+     * updated to the next node first; otherwise, it will be updated to the previous node.
+     */
+    testList->curr = testList->last->prev;
+    ASSERT_TRUE(UserDataCompare(BSL_LIST_CURR_ELMT(testList), &data[6]) == 0);
+    ASSERT_TRUE(UserDataCompare(testList->curr->next->data, &data[7]) == 0);
+    BSL_LIST_DetachNode(testList, &testList->curr);
+    ASSERT_TRUE(UserDataCompare(BSL_LIST_CURR_ELMT(testList), &data[7]) == 0);
+    ASSERT_TRUE(UserDataCompare(testList->curr->prev->data, &data[5]) == 0);
+    BSL_LIST_DetachNode(testList, &testList->curr);
+    ASSERT_TRUE(UserDataCompare(BSL_LIST_CURR_ELMT(testList), &data[5]) == 0);
 EXIT:
     BSL_LIST_FREE(testList, UserDataFree);
 }


### PR DESCRIPTION

Fix the issue where bsl_list does not adjust the current node when releasing it

Created-by: libiaoliang
Commit-by: 离标量
Merged-by: liwei3013
Description: Fix the issue where bsl_list does not adjust the current node when releasing it

See merge request: openHiTLS/openhitls!375